### PR TITLE
Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=it">Itapano</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=id">Bahasa Indonesia</a>
+      </div>
+    </div>
+  </details>
+</div>
+
 ![B2DVL Header](./assets/Bench2Drive-VL.png)
 
 🚗 **Bench2Drive-VL** is a closed-loop full-stack benchmark for vision-language models (VLMs) in autonomous driving. In VQA part, our rule-based expert model DriveCommenter is used for generating VQAs' ground truth in CARLA simulator (or from static datasets like Bench2Drive). Original Bench2Drive metrics are used for planning benchmarking.


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
And it will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=en)
- [繁體中文](https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=zh-TW)
- [日本語](https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=Thinklab-SJTU&project=Bench2Drive-VL&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962" />

If this was not your expection, please close this PR. Thank you! 🙌